### PR TITLE
Removed Lombok and refactored classes to use explicit constructors

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,6 @@ repositories {
 }
 
 dependencies {
-    compileOnly("org.projectlombok:lombok:1.18.36")
     compileOnly("io.papermc.paper:paper-api:1.21.4-R0.1-SNAPSHOT")
 
     implementation("org.bstats:bstats-bukkit:3.1.0")
@@ -36,8 +35,6 @@ dependencies {
     implementation("net.thenextlvl.core:paper:2.0.4")
     implementation("net.thenextlvl.core:files:2.0.2")
     implementation("net.thenextlvl.core:i18n:1.0.21")
-
-    annotationProcessor("org.projectlombok:lombok:1.18.36")
 }
 
 tasks.shadowJar {

--- a/src/main/java/net/thenextlvl/utilities/UtilitiesPlugin.java
+++ b/src/main/java/net/thenextlvl/utilities/UtilitiesPlugin.java
@@ -3,8 +3,6 @@ package net.thenextlvl.utilities;
 import core.file.format.GsonFile;
 import core.i18n.file.ComponentBundle;
 import core.io.IO;
-import lombok.Getter;
-import lombok.experimental.Accessors;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
@@ -21,7 +19,16 @@ import net.thenextlvl.utilities.command.aliases.DeformRotateAlias;
 import net.thenextlvl.utilities.command.aliases.ScaleAlias;
 import net.thenextlvl.utilities.command.aliases.TwistAlias;
 import net.thenextlvl.utilities.controller.SettingsController;
-import net.thenextlvl.utilities.listener.*;
+import net.thenextlvl.utilities.listener.AdvancedFlyListener;
+import net.thenextlvl.utilities.listener.AirPlacingListener;
+import net.thenextlvl.utilities.listener.BlockBreakListener;
+import net.thenextlvl.utilities.listener.BlockPhysicsListener;
+import net.thenextlvl.utilities.listener.ConnectionListener;
+import net.thenextlvl.utilities.listener.OpenableListener;
+import net.thenextlvl.utilities.listener.PlayerInteractListener;
+import net.thenextlvl.utilities.listener.SlimeListener;
+import net.thenextlvl.utilities.listener.TeleportListener;
+import net.thenextlvl.utilities.listener.WorldListener;
 import net.thenextlvl.utilities.model.NoClipManager;
 import net.thenextlvl.utilities.model.PluginConfig;
 import net.thenextlvl.utilities.version.PluginVersionChecker;
@@ -34,10 +41,9 @@ import java.io.File;
 import java.util.Locale;
 
 @NullMarked
-@Accessors(fluent = true)
 public final class UtilitiesPlugin extends JavaPlugin {
     private final File translations = new File(getDataFolder(), "translations");
-    private final @Getter ComponentBundle bundle = new ComponentBundle(translations, audience ->
+    private final ComponentBundle bundle = new ComponentBundle(translations, audience ->
             audience instanceof Player player ? player.locale() : Locale.US)
             .register("messages", Locale.US)
             .register("messages_german", Locale.GERMANY)
@@ -46,10 +52,10 @@ public final class UtilitiesPlugin extends JavaPlugin {
                     Placeholder.component("prefix", bundle.component(Locale.US, "prefix"))
             )).build());
 
-    private final @Getter SettingsController settingsController = new SettingsController();
-    private final @Getter NoClipManager noClipManager = new NoClipManager(this);
+    private final SettingsController settingsController = new SettingsController();
+    private final NoClipManager noClipManager = new NoClipManager(this);
 
-    private final @Getter PluginConfig config = new GsonFile<>(
+    private final PluginConfig config = new GsonFile<>(
             IO.of(getDataFolder(), "config.json"),
             new PluginConfig(true, true, false, true, true, true, true, true, true, false, true)
     ).validate().save().getRoot();
@@ -105,5 +111,21 @@ public final class UtilitiesPlugin extends JavaPlugin {
         new DeformRotateAlias(this).register();
         new ScaleAlias(this).register();
         new TwistAlias(this).register();
+    }
+
+    public ComponentBundle bundle() {
+        return bundle;
+    }
+
+    public SettingsController settingsController() {
+        return settingsController;
+    }
+
+    public NoClipManager noClipManager() {
+        return noClipManager;
+    }
+
+    public PluginConfig config() {
+        return config;
     }
 }

--- a/src/main/java/net/thenextlvl/utilities/command/AdvancedFlyCommand.java
+++ b/src/main/java/net/thenextlvl/utilities/command/AdvancedFlyCommand.java
@@ -3,7 +3,6 @@ package net.thenextlvl.utilities.command;
 import com.mojang.brigadier.Command;
 import io.papermc.paper.command.brigadier.Commands;
 import io.papermc.paper.plugin.lifecycle.event.types.LifecycleEvents;
-import lombok.RequiredArgsConstructor;
 import net.thenextlvl.utilities.UtilitiesPlugin;
 import org.bukkit.entity.Player;
 import org.jspecify.annotations.NullMarked;
@@ -11,9 +10,12 @@ import org.jspecify.annotations.NullMarked;
 import java.util.List;
 
 @NullMarked
-@RequiredArgsConstructor
 public class AdvancedFlyCommand {
     private final UtilitiesPlugin plugin;
+
+    public AdvancedFlyCommand(UtilitiesPlugin plugin) {
+        this.plugin = plugin;
+    }
 
     public void register() {
         var command = Commands.literal("advancedfly")

--- a/src/main/java/net/thenextlvl/utilities/command/BannerCommand.java
+++ b/src/main/java/net/thenextlvl/utilities/command/BannerCommand.java
@@ -3,7 +3,6 @@ package net.thenextlvl.utilities.command;
 import com.mojang.brigadier.Command;
 import io.papermc.paper.command.brigadier.Commands;
 import io.papermc.paper.plugin.lifecycle.event.types.LifecycleEvents;
-import lombok.RequiredArgsConstructor;
 import net.thenextlvl.utilities.UtilitiesPlugin;
 import net.thenextlvl.utilities.gui.banner.BannerGUI;
 import org.bukkit.entity.Player;
@@ -12,9 +11,12 @@ import org.jspecify.annotations.NullMarked;
 import java.util.List;
 
 @NullMarked
-@RequiredArgsConstructor
 public class BannerCommand {
     private final UtilitiesPlugin plugin;
+
+    public BannerCommand(UtilitiesPlugin plugin) {
+        this.plugin = plugin;
+    }
 
     public void register() {
         var command = Commands.literal("banner")

--- a/src/main/java/net/thenextlvl/utilities/command/ColorCommand.java
+++ b/src/main/java/net/thenextlvl/utilities/command/ColorCommand.java
@@ -3,7 +3,6 @@ package net.thenextlvl.utilities.command;
 import com.mojang.brigadier.Command;
 import io.papermc.paper.command.brigadier.Commands;
 import io.papermc.paper.plugin.lifecycle.event.types.LifecycleEvents;
-import lombok.RequiredArgsConstructor;
 import net.thenextlvl.utilities.UtilitiesPlugin;
 import net.thenextlvl.utilities.gui.ArmorCreatorGUI;
 import org.bukkit.entity.Player;
@@ -12,9 +11,12 @@ import org.jspecify.annotations.NullMarked;
 import java.util.List;
 
 @NullMarked
-@RequiredArgsConstructor
 public class ColorCommand {
     private final UtilitiesPlugin plugin;
+
+    public ColorCommand(UtilitiesPlugin plugin) {
+        this.plugin = plugin;
+    }
 
     public void register() {
         var command = Commands.literal("armorcolor")

--- a/src/main/java/net/thenextlvl/utilities/command/NightVisionCommand.java
+++ b/src/main/java/net/thenextlvl/utilities/command/NightVisionCommand.java
@@ -3,7 +3,6 @@ package net.thenextlvl.utilities.command;
 import com.mojang.brigadier.Command;
 import io.papermc.paper.command.brigadier.Commands;
 import io.papermc.paper.plugin.lifecycle.event.types.LifecycleEvents;
-import lombok.RequiredArgsConstructor;
 import net.thenextlvl.utilities.UtilitiesPlugin;
 import org.bukkit.entity.Player;
 import org.bukkit.potion.PotionEffect;
@@ -13,7 +12,6 @@ import org.jspecify.annotations.NullMarked;
 import java.util.List;
 
 @NullMarked
-@RequiredArgsConstructor
 public class NightVisionCommand {
     private final PotionEffect nightVision = new PotionEffect(
             PotionEffectType.NIGHT_VISION,
@@ -21,6 +19,10 @@ public class NightVisionCommand {
             0, true, false
     );
     private final UtilitiesPlugin plugin;
+
+    public NightVisionCommand(UtilitiesPlugin plugin) {
+        this.plugin = plugin;
+    }
 
     public void register() {
         var command = Commands.literal("nightvision")

--- a/src/main/java/net/thenextlvl/utilities/command/NoClipCommand.java
+++ b/src/main/java/net/thenextlvl/utilities/command/NoClipCommand.java
@@ -3,7 +3,6 @@ package net.thenextlvl.utilities.command;
 import com.mojang.brigadier.Command;
 import io.papermc.paper.command.brigadier.Commands;
 import io.papermc.paper.plugin.lifecycle.event.types.LifecycleEvents;
-import lombok.RequiredArgsConstructor;
 import net.thenextlvl.utilities.UtilitiesPlugin;
 import org.bukkit.entity.Player;
 import org.jspecify.annotations.NullMarked;
@@ -11,9 +10,12 @@ import org.jspecify.annotations.NullMarked;
 import java.util.List;
 
 @NullMarked
-@RequiredArgsConstructor
 public class NoClipCommand {
     private final UtilitiesPlugin plugin;
+
+    public NoClipCommand(UtilitiesPlugin plugin) {
+        this.plugin = plugin;
+    }
 
     public void register() {
         var command = Commands.literal("noclip")

--- a/src/main/java/net/thenextlvl/utilities/command/PotteryCommand.java
+++ b/src/main/java/net/thenextlvl/utilities/command/PotteryCommand.java
@@ -3,7 +3,6 @@ package net.thenextlvl.utilities.command;
 import com.mojang.brigadier.Command;
 import io.papermc.paper.command.brigadier.Commands;
 import io.papermc.paper.plugin.lifecycle.event.types.LifecycleEvents;
-import lombok.RequiredArgsConstructor;
 import net.thenextlvl.utilities.UtilitiesPlugin;
 import net.thenextlvl.utilities.gui.pottery.PotteryDesignerGUI;
 import org.bukkit.Material;
@@ -12,9 +11,12 @@ import org.bukkit.inventory.ItemStack;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
-@RequiredArgsConstructor
 public class PotteryCommand {
     private final UtilitiesPlugin plugin;
+
+    public PotteryCommand(UtilitiesPlugin plugin) {
+        this.plugin = plugin;
+    }
 
     public void register() {
         var command = Commands.literal("pottery")

--- a/src/main/java/net/thenextlvl/utilities/command/UtilsCommand.java
+++ b/src/main/java/net/thenextlvl/utilities/command/UtilsCommand.java
@@ -3,7 +3,6 @@ package net.thenextlvl.utilities.command;
 import com.mojang.brigadier.Command;
 import io.papermc.paper.command.brigadier.Commands;
 import io.papermc.paper.plugin.lifecycle.event.types.LifecycleEvents;
-import lombok.RequiredArgsConstructor;
 import net.thenextlvl.utilities.UtilitiesPlugin;
 import net.thenextlvl.utilities.gui.UtilitiesGUI;
 import org.bukkit.entity.Player;
@@ -12,9 +11,12 @@ import org.jspecify.annotations.NullMarked;
 import java.util.List;
 
 @NullMarked
-@RequiredArgsConstructor
 public class UtilsCommand {
     private final UtilitiesPlugin plugin;
+
+    public UtilsCommand(UtilitiesPlugin plugin) {
+        this.plugin = plugin;
+    }
 
     public void register() {
         var command = Commands.literal("utils")

--- a/src/main/java/net/thenextlvl/utilities/command/aliases/ConvexSelectionAlias.java
+++ b/src/main/java/net/thenextlvl/utilities/command/aliases/ConvexSelectionAlias.java
@@ -3,16 +3,18 @@ package net.thenextlvl.utilities.command.aliases;
 import com.mojang.brigadier.Command;
 import io.papermc.paper.command.brigadier.Commands;
 import io.papermc.paper.plugin.lifecycle.event.types.LifecycleEvents;
-import lombok.RequiredArgsConstructor;
 import net.thenextlvl.utilities.UtilitiesPlugin;
 import org.jspecify.annotations.NullMarked;
 
 import java.util.List;
 
 @NullMarked
-@RequiredArgsConstructor
 public class ConvexSelectionAlias {
     private final UtilitiesPlugin plugin;
+
+    public ConvexSelectionAlias(UtilitiesPlugin plugin) {
+        this.plugin = plugin;
+    }
 
     public void register() {
         var command = Commands.literal("/convex")

--- a/src/main/java/net/thenextlvl/utilities/command/aliases/CuboidSelectionAlias.java
+++ b/src/main/java/net/thenextlvl/utilities/command/aliases/CuboidSelectionAlias.java
@@ -3,16 +3,18 @@ package net.thenextlvl.utilities.command.aliases;
 import com.mojang.brigadier.Command;
 import io.papermc.paper.command.brigadier.Commands;
 import io.papermc.paper.plugin.lifecycle.event.types.LifecycleEvents;
-import lombok.RequiredArgsConstructor;
 import net.thenextlvl.utilities.UtilitiesPlugin;
 import org.jspecify.annotations.NullMarked;
 
 import java.util.List;
 
 @NullMarked
-@RequiredArgsConstructor
 public class CuboidSelectionAlias {
     private final UtilitiesPlugin plugin;
+
+    public CuboidSelectionAlias(UtilitiesPlugin plugin) {
+        this.plugin = plugin;
+    }
 
     public void register() {
         var command = Commands.literal("/cuboid")

--- a/src/main/java/net/thenextlvl/utilities/command/aliases/DeformRotateAlias.java
+++ b/src/main/java/net/thenextlvl/utilities/command/aliases/DeformRotateAlias.java
@@ -4,15 +4,17 @@ import com.mojang.brigadier.Command;
 import com.mojang.brigadier.arguments.IntegerArgumentType;
 import io.papermc.paper.command.brigadier.Commands;
 import io.papermc.paper.plugin.lifecycle.event.types.LifecycleEvents;
-import lombok.RequiredArgsConstructor;
 import net.thenextlvl.utilities.UtilitiesPlugin;
 import org.bukkit.Axis;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
-@RequiredArgsConstructor
 public class DeformRotateAlias {
     private final UtilitiesPlugin plugin;
+
+    public DeformRotateAlias(UtilitiesPlugin plugin) {
+        this.plugin = plugin;
+    }
 
     public void register() {
         var command = Commands.literal("/derot")

--- a/src/main/java/net/thenextlvl/utilities/command/aliases/ScaleAlias.java
+++ b/src/main/java/net/thenextlvl/utilities/command/aliases/ScaleAlias.java
@@ -4,16 +4,18 @@ import com.mojang.brigadier.Command;
 import com.mojang.brigadier.arguments.IntegerArgumentType;
 import io.papermc.paper.command.brigadier.Commands;
 import io.papermc.paper.plugin.lifecycle.event.types.LifecycleEvents;
-import lombok.RequiredArgsConstructor;
 import net.thenextlvl.utilities.UtilitiesPlugin;
 import org.jspecify.annotations.NullMarked;
 
 import java.util.List;
 
 @NullMarked
-@RequiredArgsConstructor
 public class ScaleAlias {
     private final UtilitiesPlugin plugin;
+
+    public ScaleAlias(UtilitiesPlugin plugin) {
+        this.plugin = plugin;
+    }
 
     public void register() {
         var command = Commands.literal("/scale")

--- a/src/main/java/net/thenextlvl/utilities/command/aliases/TwistAlias.java
+++ b/src/main/java/net/thenextlvl/utilities/command/aliases/TwistAlias.java
@@ -4,15 +4,17 @@ import com.mojang.brigadier.Command;
 import com.mojang.brigadier.arguments.IntegerArgumentType;
 import io.papermc.paper.command.brigadier.Commands;
 import io.papermc.paper.plugin.lifecycle.event.types.LifecycleEvents;
-import lombok.RequiredArgsConstructor;
 import net.thenextlvl.utilities.UtilitiesPlugin;
 import org.bukkit.Axis;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
-@RequiredArgsConstructor
 public class TwistAlias {
     private final UtilitiesPlugin plugin;
+
+    public TwistAlias(UtilitiesPlugin plugin) {
+        this.plugin = plugin;
+    }
 
     public void register() {
         var command = Commands.literal("/twist")

--- a/src/main/java/net/thenextlvl/utilities/controller/SettingsController.java
+++ b/src/main/java/net/thenextlvl/utilities/controller/SettingsController.java
@@ -1,6 +1,5 @@
 package net.thenextlvl.utilities.controller;
 
-import lombok.Getter;
 import org.bukkit.entity.Player;
 import org.jspecify.annotations.NullMarked;
 
@@ -8,7 +7,6 @@ import java.util.Collections;
 import java.util.Set;
 import java.util.WeakHashMap;
 
-@Getter
 @NullMarked
 @SuppressWarnings({"UnusedReturnValue", "BooleanMethodIsAlwaysInverted"})
 public class SettingsController {
@@ -84,5 +82,9 @@ public class SettingsController {
         noClip.remove(player);
         openable.remove(player);
         slabPartBreaking.remove(player);
+    }
+
+    public Set<Player> getNoClip() {
+        return noClip;
     }
 }

--- a/src/main/java/net/thenextlvl/utilities/listener/AdvancedFlyListener.java
+++ b/src/main/java/net/thenextlvl/utilities/listener/AdvancedFlyListener.java
@@ -1,6 +1,5 @@
 package net.thenextlvl.utilities.listener;
 
-import lombok.RequiredArgsConstructor;
 import net.thenextlvl.utilities.UtilitiesPlugin;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -15,12 +14,15 @@ import java.util.Set;
 import java.util.WeakHashMap;
 
 @NullMarked
-@RequiredArgsConstructor
 public class AdvancedFlyListener implements Listener {
     static final Map<Player, Double> lastVelocity = new WeakHashMap<>();
     static final Set<Player> slower1 = Collections.newSetFromMap(new WeakHashMap<>());
     static final Set<Player> slower2 = Collections.newSetFromMap(new WeakHashMap<>());
     private final UtilitiesPlugin plugin;
+
+    public AdvancedFlyListener(UtilitiesPlugin plugin) {
+        this.plugin = plugin;
+    }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onPlayerMove(PlayerMoveEvent event) {

--- a/src/main/java/net/thenextlvl/utilities/listener/AirPlacingListener.java
+++ b/src/main/java/net/thenextlvl/utilities/listener/AirPlacingListener.java
@@ -1,6 +1,5 @@
 package net.thenextlvl.utilities.listener;
 
-import lombok.RequiredArgsConstructor;
 import net.thenextlvl.utilities.UtilitiesPlugin;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -19,13 +18,16 @@ import java.util.Map;
 import java.util.WeakHashMap;
 
 @NullMarked
-@RequiredArgsConstructor
 public class AirPlacingListener implements Listener {
     static final Map<Player, Location> targetBlocks = new WeakHashMap<>();
     private final BlockData blockData = Material.BARRIER.createBlockData();
     private final BlockData waterlogged = Material.BARRIER.createBlockData(data ->
             ((Waterlogged) data).setWaterlogged(true));
     private final UtilitiesPlugin plugin;
+
+    public AirPlacingListener(UtilitiesPlugin plugin) {
+        this.plugin = plugin;
+    }
 
     @EventHandler(priority = EventPriority.MONITOR)
     public void onPlayerQuit(PlayerQuitEvent event) {

--- a/src/main/java/net/thenextlvl/utilities/listener/BlockBreakListener.java
+++ b/src/main/java/net/thenextlvl/utilities/listener/BlockBreakListener.java
@@ -1,6 +1,5 @@
 package net.thenextlvl.utilities.listener;
 
-import lombok.RequiredArgsConstructor;
 import net.thenextlvl.utilities.UtilitiesPlugin;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.block.BlockFace;
@@ -16,9 +15,12 @@ import static org.bukkit.block.data.type.Slab.Type.BOTTOM;
 import static org.bukkit.block.data.type.Slab.Type.TOP;
 
 @NullMarked
-@RequiredArgsConstructor
 public class BlockBreakListener implements Listener {
     private final UtilitiesPlugin plugin;
+
+    public BlockBreakListener(UtilitiesPlugin plugin) {
+        this.plugin = plugin;
+    }
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onSlabBreak(BlockBreakEvent event) {

--- a/src/main/java/net/thenextlvl/utilities/listener/BlockPhysicsListener.java
+++ b/src/main/java/net/thenextlvl/utilities/listener/BlockPhysicsListener.java
@@ -1,6 +1,5 @@
 package net.thenextlvl.utilities.listener;
 
-import lombok.RequiredArgsConstructor;
 import net.thenextlvl.utilities.UtilitiesPlugin;
 import org.bukkit.Material;
 import org.bukkit.block.BlockFace;
@@ -10,9 +9,12 @@ import org.bukkit.event.block.BlockPhysicsEvent;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
-@RequiredArgsConstructor
 public class BlockPhysicsListener implements Listener {
     private final UtilitiesPlugin plugin;
+
+    public BlockPhysicsListener(UtilitiesPlugin plugin) {
+        this.plugin = plugin;
+    }
 
     @EventHandler
     public void onPhysics(BlockPhysicsEvent event) {

--- a/src/main/java/net/thenextlvl/utilities/listener/ConnectionListener.java
+++ b/src/main/java/net/thenextlvl/utilities/listener/ConnectionListener.java
@@ -1,6 +1,5 @@
 package net.thenextlvl.utilities.listener;
 
-import lombok.RequiredArgsConstructor;
 import net.thenextlvl.utilities.UtilitiesPlugin;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.event.EventHandler;
@@ -13,9 +12,12 @@ import org.jspecify.annotations.NullMarked;
 import java.util.Optional;
 
 @NullMarked
-@RequiredArgsConstructor
 public class ConnectionListener implements Listener {
     private final UtilitiesPlugin plugin;
+
+    public ConnectionListener(UtilitiesPlugin plugin) {
+        this.plugin = plugin;
+    }
 
     @EventHandler(priority = EventPriority.MONITOR)
     public void onPlayerJoin(PlayerJoinEvent event) {

--- a/src/main/java/net/thenextlvl/utilities/listener/OpenableListener.java
+++ b/src/main/java/net/thenextlvl/utilities/listener/OpenableListener.java
@@ -1,6 +1,5 @@
 package net.thenextlvl.utilities.listener;
 
-import lombok.RequiredArgsConstructor;
 import net.thenextlvl.utilities.UtilitiesPlugin;
 import org.bukkit.Material;
 import org.bukkit.Sound;
@@ -15,9 +14,12 @@ import org.bukkit.inventory.EquipmentSlot;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
-@RequiredArgsConstructor
 public class OpenableListener implements Listener {
     private final UtilitiesPlugin plugin;
+
+    public OpenableListener(UtilitiesPlugin plugin) {
+        this.plugin = plugin;
+    }
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onPlayerInteract(PlayerInteractEvent event) {

--- a/src/main/java/net/thenextlvl/utilities/listener/PlayerInteractListener.java
+++ b/src/main/java/net/thenextlvl/utilities/listener/PlayerInteractListener.java
@@ -1,6 +1,5 @@
 package net.thenextlvl.utilities.listener;
 
-import lombok.RequiredArgsConstructor;
 import net.thenextlvl.utilities.UtilitiesPlugin;
 import org.bukkit.Material;
 import org.bukkit.event.EventHandler;
@@ -12,9 +11,12 @@ import org.bukkit.event.player.PlayerInteractEvent;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
-@RequiredArgsConstructor
 public class PlayerInteractListener implements Listener {
     private final UtilitiesPlugin plugin;
+
+    public PlayerInteractListener(UtilitiesPlugin plugin) {
+        this.plugin = plugin;
+    }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onDragonEggTeleport(BlockFromToEvent event) {

--- a/src/main/java/net/thenextlvl/utilities/listener/SlimeListener.java
+++ b/src/main/java/net/thenextlvl/utilities/listener/SlimeListener.java
@@ -1,6 +1,5 @@
 package net.thenextlvl.utilities.listener;
 
-import lombok.RequiredArgsConstructor;
 import net.thenextlvl.utilities.UtilitiesPlugin;
 import org.bukkit.GameMode;
 import org.bukkit.Material;
@@ -18,9 +17,12 @@ import org.bukkit.inventory.EquipmentSlot;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
-@RequiredArgsConstructor
 public class SlimeListener implements Listener {
     private final UtilitiesPlugin plugin;
+
+    public SlimeListener(UtilitiesPlugin plugin) {
+        this.plugin = plugin;
+    }
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onPlayerSlimePiston(PlayerInteractEvent event) {

--- a/src/main/java/net/thenextlvl/utilities/listener/WorldListener.java
+++ b/src/main/java/net/thenextlvl/utilities/listener/WorldListener.java
@@ -1,6 +1,5 @@
 package net.thenextlvl.utilities.listener;
 
-import lombok.RequiredArgsConstructor;
 import net.thenextlvl.utilities.UtilitiesPlugin;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -12,9 +11,12 @@ import org.bukkit.event.weather.WeatherChangeEvent;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
-@RequiredArgsConstructor
 public class WorldListener implements Listener {
     private final UtilitiesPlugin plugin;
+
+    public WorldListener(UtilitiesPlugin plugin) {
+        this.plugin = plugin;
+    }
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onBlockFade(BlockFadeEvent event) {

--- a/src/main/java/net/thenextlvl/utilities/model/NoClipManager.java
+++ b/src/main/java/net/thenextlvl/utilities/model/NoClipManager.java
@@ -1,15 +1,17 @@
 package net.thenextlvl.utilities.model;
 
-import lombok.RequiredArgsConstructor;
 import net.thenextlvl.utilities.UtilitiesPlugin;
 import org.bukkit.GameMode;
 import org.bukkit.entity.Player;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
-@RequiredArgsConstructor
 public class NoClipManager {
     private final UtilitiesPlugin plugin;
+
+    public NoClipManager(UtilitiesPlugin plugin) {
+        this.plugin = plugin;
+    }
 
     public void start() {
         plugin.getServer().getGlobalRegionScheduler().runAtFixedRate(plugin, task -> plugin.settingsController()

--- a/src/main/java/net/thenextlvl/utilities/version/PluginVersionChecker.java
+++ b/src/main/java/net/thenextlvl/utilities/version/PluginVersionChecker.java
@@ -2,12 +2,10 @@ package net.thenextlvl.utilities.version;
 
 import core.paper.version.PaperHangarVersionChecker;
 import core.version.SemanticVersion;
-import lombok.Getter;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.Nullable;
 import org.jspecify.annotations.NullMarked;
 
-@Getter
 @NullMarked
 public class PluginVersionChecker extends PaperHangarVersionChecker<SemanticVersion> {
     public PluginVersionChecker(Plugin plugin) {


### PR DESCRIPTION
Replaced Lombok annotations like `@Getter`, `@Accessors`, and `@RequiredArgsConstructor` with explicit methods and constructors for better control and readability.