### PR TITLE
Bumped `paper` dependency to version 2.1.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
 
     implementation("org.bstats:bstats-bukkit:3.1.0")
     implementation("net.thenextlvl.core:adapters:2.0.2")
-    implementation("net.thenextlvl.core:paper:2.1.1")
+    implementation("net.thenextlvl.core:paper:2.1.2")
     implementation("net.thenextlvl.core:files:3.0.0")
     implementation("net.thenextlvl.core:i18n:3.2.0")
 }


### PR DESCRIPTION
Updated to the latest version for improved features and fixes.